### PR TITLE
Added setting to allow player execution of note macros

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -11,6 +11,8 @@
   "settings.eventKey.title" : "Choose Key",
   "settings.eventKey.hint" : "When clicking on a exposed note with this key depressed will execute the stored macro in the Note.",
 
+  "settings.permission.title" : "Player Execution",
+  "settings.permission.hint" : "Allow players to execute note macros",
 
   "error.editImage":"You cannot edit the icon for this macro.",
   "error.setMacro":"Incorrect macro type",

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -103,9 +103,10 @@ export class helper{
     const orig = Canvas.prototype._onClickLeft;
     Canvas.prototype._onClickLeft = function(event){
       logger.debug("Click Detected | Accepted : ", event.data.originalEvent[settings.value("eventKey")]);
-      if(event.data.originalEvent[settings.value("eventKey")] && game.user.isGM){
+      //Execute if the key is held and gm or if player execution is enabled
+      if(event.data.originalEvent[settings.value("eventKey")] && (game.user.isGM||settings.value("permission"))){ 
         const note = this.notes?._hover;
-
+        logger.debug("Corresponding Note:",note)
         if(note) note.executeMacro(event);
       }else{
         orig.call(this, event);

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -32,6 +32,7 @@ export class settings {
       icon : { scope : "world", config : true, default : false, type : Boolean },
       eventKey : { scope : "client", config : true, default : "shiftKey", type : String, choices : settings.eventKeys, onChange : ()=> window.location.reload() },
       journal : { scope : "world", config : true, default : false, type : Boolean },
+      permission:{scope: "world", config: true, default: false, type: Boolean}
     };
 
     Object.entries(settingData).forEach(([key, data])=> {


### PR DESCRIPTION
I was very surprised to learn that while players were able to select what key has to be held so that note macros are executed, they were not able to execute them either way. This PR adds a setting that if enabled allows for player execution of note macros.